### PR TITLE
Add minimal standalone server example

### DIFF
--- a/standalone-example/README.md
+++ b/standalone-example/README.md
@@ -1,0 +1,10 @@
+# Standalone Example
+
+This module demonstrates a minimal setup of the JDT language server without the Eclipse platform. It uses only `lsp4j` and the `org.eclipse.jdt.core` library.
+
+Run the server with:
+
+```bash
+mvn package
+java -cp target/standalone-example-0.1.0-SNAPSHOT.jar org.eclipse.jdt.ls.standalone.MinimalLanguageServer
+```

--- a/standalone-example/pom.xml
+++ b/standalone-example/pom.xml
@@ -1,0 +1,28 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eclipse.jdt.ls</groupId>
+  <artifactId>standalone-example</artifactId>
+  <version>0.1.0-SNAPSHOT</version>
+  <name>Minimal JDT LS Example</name>
+  <properties>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.lsp4j</groupId>
+      <artifactId>org.eclipse.lsp4j</artifactId>
+      <version>0.24.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.core</artifactId>
+      <version>3.42.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.12</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/MinimalLanguageServer.java
+++ b/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/MinimalLanguageServer.java
@@ -1,0 +1,16 @@
+package org.eclipse.jdt.ls.standalone;
+
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+
+/**
+ * Entry point that starts the minimal language server using stdio.
+ */
+public class MinimalLanguageServer {
+    public static void main(String[] args) throws Exception {
+        SimpleLanguageServer server = new SimpleLanguageServer();
+        Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, System.in, System.out);
+        launcher.startListening();
+    }
+}

--- a/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/SimpleLanguageServer.java
+++ b/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/SimpleLanguageServer.java
@@ -1,0 +1,53 @@
+package org.eclipse.jdt.ls.standalone;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageClientAware;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+/**
+ * Very small {@link LanguageServer} implementation used for demonstration.
+ */
+public class SimpleLanguageServer implements LanguageServer, LanguageClientAware {
+
+    private final TextDocumentService textService = new SimpleTextDocumentService();
+    private final WorkspaceService workspaceService = new SimpleWorkspaceService();
+    private LanguageClient client;
+
+    @Override
+    public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+        InitializeResult result = new InitializeResult(new ServerCapabilities());
+        return CompletableFuture.completedFuture(result);
+    }
+
+    @Override
+    public CompletableFuture<Object> shutdown() {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void exit() {
+        // nothing
+    }
+
+    @Override
+    public TextDocumentService getTextDocumentService() {
+        return textService;
+    }
+
+    @Override
+    public WorkspaceService getWorkspaceService() {
+        return workspaceService;
+    }
+
+    @Override
+    public void connect(LanguageClient client) {
+        this.client = client;
+    }
+}

--- a/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/SimpleTextDocumentService.java
+++ b/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/SimpleTextDocumentService.java
@@ -1,0 +1,43 @@
+package org.eclipse.jdt.ls.standalone;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+/**
+ * Minimal text document service providing empty implementations.
+ */
+public class SimpleTextDocumentService implements TextDocumentService {
+
+    @Override
+    public void didOpen(DidOpenTextDocumentParams params) {
+    }
+
+    @Override
+    public void didChange(DidChangeTextDocumentParams params) {
+    }
+
+    @Override
+    public void didClose(DidCloseTextDocumentParams params) {
+    }
+
+    @Override
+    public void didSave(DidSaveTextDocumentParams params) {
+    }
+
+    @Override
+    public CompletableFuture<org.eclipse.lsp4j.jsonrpc.messages.Either<java.util.List<CompletionItem>, CompletionList>> completion(org.eclipse.lsp4j.CompletionParams params) {
+        return CompletableFuture.completedFuture(org.eclipse.lsp4j.jsonrpc.messages.Either.forRight(new CompletionList()));
+    }
+
+    @Override
+    public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
+        return CompletableFuture.completedFuture(unresolved);
+    }
+}

--- a/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/SimpleWorkspaceService.java
+++ b/standalone-example/src/main/java/org/eclipse/jdt/ls/standalone/SimpleWorkspaceService.java
@@ -1,0 +1,28 @@
+package org.eclipse.jdt.ls.standalone;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+/**
+ * Minimal workspace service with no functionality.
+ */
+public class SimpleWorkspaceService implements WorkspaceService {
+
+    @Override
+    public CompletableFuture<Object> executeCommand(org.eclipse.lsp4j.ExecuteCommandParams params) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void didChangeConfiguration(org.eclipse.lsp4j.DidChangeConfigurationParams params) {
+    }
+
+    @Override
+    public void didChangeWatchedFiles(org.eclipse.lsp4j.DidChangeWatchedFilesParams params) {
+    }
+
+    @Override
+    public void didChangeWorkspaceFolders(org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams params) {
+    }
+}


### PR DESCRIPTION
## Summary
- create `standalone-example` module with pom
- add extremely small language server implementation using lsp4j
- document how to build and run the sample

## Testing
- `mvn -q -f standalone-example/pom.xml package`

------
https://chatgpt.com/codex/tasks/task_e_6873dc9cfa6483249433320be91f2c63